### PR TITLE
Add deprecation notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@ Is a small tool to help ensure that your project does not contain any vulnerable
 We do this by scraping information from [gemnasium](https://gemnasium.com),
 please keep in mind that the use of Gemnasium's information is governed by their [terms and conditions](https://gemnasium.com/terms).
 
+## This project is now deprecated
+
+In May 2018, [Gemnasium was acquired by GitLab]. Since Gemnasium is no longer availble
+as a standalone service, this project no longer serves any practical purpose. This repo
+will remain as a historical reference but it will no longer work.
+
 ## Installing gem_checks
 Via Rubygems:
 ```
@@ -26,5 +32,6 @@ more details.
 ## License
 Gem Checks is free software, and may be redistributed under the terms specified in the [license].
 
+[Gemnasium was acquired by GitLab]: https://docs.gitlab.com/ee/user/project/import/gemnasium.html
 [contributing guide]: https://github.com/mobiledefense/gem_checks/blob/master/CONTRIBUTING.md
 [license]: https://github.com/mobiledefense/gem_checks/blob/master/LICENSE.txt


### PR DESCRIPTION
Since Gemnasium is no longer a standalone service, this gem can no
longer function as it is. This gem could potentially be updated to use
something like
[bundler-audit](https://github.com/rubysec/bundler-audit).

## Question for the reviewer(s)

We could update this project to use `bundler-audit` instead of completely deprecating it. Would that be useful?